### PR TITLE
Visual upgrade for slack notifications + personal notifications for followed subjects

### DIFF
--- a/app/controllers/subjects_controller.rb
+++ b/app/controllers/subjects_controller.rb
@@ -102,9 +102,8 @@ class SubjectsController < ApplicationController
 			update_unread_subjects
 			# Send mail to followers
 			@subject.following_users.each do |u|
-				if u != @current_user
-					#TODO: Get the slack username and use @username as channel in this call
-					# send_notification(@subject, @message, nil)
+				if u != @current_user and u.slack
+					send_notification(@subject, @message, "@#{u.slack}")
 				end
 			end
 			redirect_to "/subjects/#{@subject.id}?page=last"

--- a/app/controllers/subjects_controller.rb
+++ b/app/controllers/subjects_controller.rb
@@ -1,5 +1,5 @@
 class SubjectsController < ApplicationController
-	before_action :authenticate_user, :only => [:new, :create, :edit, :update, :create_message, :toggle_pinned, :start_following_subject, :stop_following_subject, :start_following_forum, :stop_following_forum]
+	before_action :authenticate_user, :only => [:new, :create, :edit, :update, :create_message, :toggle_pinned, :start_following_subject, :stop_following_subject]
 	before_action only: [:index, :show] do
 		authenticate_user(false)
 	end
@@ -131,16 +131,6 @@ class SubjectsController < ApplicationController
 			@subject.following_users.delete(@current_user)
 		end
 		redirect_to "/subjects/#{@subject.id}"
-	end
-
-	def start_following_forum
-		@current_user.update(should_notify_new_subjects: true)
-		redirect_to "/subjects"
-	end
-
-	def stop_following_forum
-		@current_user.update(should_notify_new_subjects: false)
-		redirect_to "/subjects"
 	end
 
 	private

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -76,10 +76,10 @@ class UsersController < ApplicationController
 
 	private
 		def new_user_params
-			params.require(:user).permit(:username, :uva, :codeforces, :display_name, :initials, :email, :admin, :inscription_date, :password, :password_confirmation)
+			params.require(:user).permit(:username, :uva, :codeforces, :slack, :display_name, :initials, :email, :admin, :inscription_date, :password, :password_confirmation)
 		end
 
 		def update_user_params
-			params.require(:user).permit(:uva, :codeforces, :display_name, :initials, :is_contestant, :in_event)
+			params.require(:user).permit(:uva, :codeforces, :slack, :display_name, :initials, :is_contestant, :in_event)
 		end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -16,10 +16,12 @@ class User < ApplicationRecord
 	EMAIL_REGEX = /\A[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,4}\z/i
 	UVA_USERNAME_REGEX = /\A[\p{L}\p{N}_]{3,}\z/i
 	CODEFORCES_USERNAME_REGEX = /\A[\p{L}\p{N}_]{3,24}\z/i
+	SLACK_USERNAME_REGEX = /\A[a-z0-9._-]{1,21}\z/i
 
 	validates :username, :presence => true, :uniqueness => true, :length => { :in => 3..40 }
 	validates :uva, :uniqueness => true, :format => UVA_USERNAME_REGEX, :allow_blank => true
 	validates :codeforces, :uniqueness => true, :format => CODEFORCES_USERNAME_REGEX, :allow_blank => true
+	validates :slack, :uniqueness => true, :format => SLACK_USERNAME_REGEX, :allow_blank => true
 	validates :email, :presence => true, :uniqueness => true, :format => EMAIL_REGEX
 	validates :display_name, :length => { :in => 3..40 }, :uniqueness => true
 	validates :initials, :length => { :in => 2..6 }, :uniqueness => true, :allow_blank => true

--- a/app/views/subjects/index.html.erb
+++ b/app/views/subjects/index.html.erb
@@ -6,13 +6,7 @@
 		<strong>Forum</strong>
 		<!-- Following (only if the user is logged in) -->
 		<div style="float: right;">
-			<% if @current_user %>
-				<% if @current_user.should_notify_new_subjects %>
-					<%= link_to "Stop following the forum", "/subjects/stop_following_forum", method: :patch, class: "btn btn-default btn-gray" %>
-				<% else %>
-					<%= link_to "Follow the forum", "/subjects/start_following_forum", method: :patch, data: {confirm: "You will receive a mail for every new subject posted on the forum."}, class: "btn btn-default btn-gray" %>
-				<% end %>
-			<% end %>
+			<div class="btn btn-default btn-gray" onclick="javascript:alert('Please join #beoi-training-forum in the be-algo slack group')">Follow the forum</div>
 		</div>
 	</div>
 	<div class="panel-body">

--- a/app/views/users/profile.html.erb
+++ b/app/views/users/profile.html.erb
@@ -16,6 +16,11 @@
 		</div>
 
 		<div class="form-group">
+			<%= ApplicationHelper.f_label t(:slack) %><br>
+			<%= f.text_field :slack, class: "form-control", placeholder: t(:slack) %>
+		</div>
+
+		<div class="form-group">
 			<%= ApplicationHelper.f_label t(:display_name) %><br>
 			<%= f.text_field :display_name, class: "form-control", placeholder: t(:display_name) %>
 			<a style="cursor: pointer;" onclick="fetch_uva_id();">(Fetch from UVa)</a>

--- a/app/views/users/signup.html.erb
+++ b/app/views/users/signup.html.erb
@@ -4,48 +4,53 @@
 	</div>
 	<div class="panel-body">
 	<%= form_for @user, url: {action: "create"} do |f| %>
-		
+
 		<div class="form-group">
 			<%= ApplicationHelper.f_label t(:username)%><br>
 			<%= f.text_field :username, class: "form-control", style: "width: 250px;", placeholder: t(:username) %>
 		</div>
-		
+
 		<div class="form-group">
 			<%= ApplicationHelper.f_label t(:uva)%><br>
 			<%= f.text_field :uva, class: "form-control", style: "width: 250px;", placeholder: t(:uva) %>
 		</div>
-		
+
 		<div class="form-group">
 			<%= ApplicationHelper.f_label t(:codeforces)%><br>
 			<%= f.text_field :codeforces, class: "form-control", style: "width: 250px;", placeholder: t(:codeforces) %>
 		</div>
-		
+
+		<div class="form-group">
+			<%= ApplicationHelper.f_label t(:slack)%><br>
+			<%= f.text_field :slack, class: "form-control", style: "width: 250px;", placeholder: t(:slack) %>
+		</div>
+
 		<div class="form-group">
 			<%= ApplicationHelper.f_label t(:display_name)%><br>
 			<%= f.text_field :display_name, class: "form-control", style: "width: 250px;", placeholder: t(:display_name) %>
 			<a style="cursor: pointer;" onclick="fetch_uva_id();">(Fetch from UVa)</a>
 		</div>
-		
+
 		<div class="form-group">
 			<%= ApplicationHelper.f_label t(:initials) %><br>
 			<%= f.text_field :initials, class: "form-control", style: "width: 250px;", placeholder: t(:initials) %>
 		</div>
-		
+
 		<div class="form-group">
 			<%= ApplicationHelper.f_label t(:email)%><br>
 			<%= f.text_field :email, class: "form-control", style: "width: 250px;", placeholder: t(:email) %>
 		</div>
-		
+
 		<div class="form-group">
 			<%= ApplicationHelper.f_label t(:password)%><br>
 			<%= f.password_field :password, class: "form-control", style: "width: 250px;", placeholder: t(:password) %>
 		</div>
-		
+
 		<div class="form-group">
 			<%= ApplicationHelper.f_label t(:password_confirmation)%><br>
 			<%= f.password_field :password_confirmation, class: "form-control", style: "width: 250px;", placeholder: t(:password_confirmation) %>
 		</div>
-		
+
 		<%= f.submit class: "btn btn-default btn-primary", style: "width:250px;" %>
 
 	<% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -24,6 +24,7 @@ en:
     username: "Username"
     uva: "UVa Onlinejudge username"
     codeforces: "Codeforces handle"
+    slack: "Slack username or user ID"
     display_name: "Displayed name"
     initials: "Initials"
     email: "Email address"

--- a/db/migrate/20180209142112_add_slack_to_user.rb
+++ b/db/migrate/20180209142112_add_slack_to_user.rb
@@ -1,0 +1,5 @@
+class AddSlackToUser < ActiveRecord::Migration[5.0]
+  def change
+    add_column :users, :slack, :string, limit: 21
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170131210340) do
+ActiveRecord::Schema.define(version: 20180209142112) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -117,6 +117,7 @@ ActiveRecord::Schema.define(version: 20170131210340) do
     t.string   "codeforces"
     t.string   "initials"
     t.boolean  "should_notify_new_subjects"
+    t.string   "slack",                      limit: 21
   end
 
 end


### PR DESCRIPTION
I did a refactor that makes it possible to re-use the same code to notify people of replies
People who are following a subject and have their slack username or user id set should now receive notifications on updates
The "Follow the forum" button now prompts people to join #beoi-training-forum in the be-algo slack
And on top of that, I made some visual improvements using message attachments (it now clearly as an author, title (potentially prefixed with 'Reply to:') and a short extract of the message body
The color on the left of the attachment also indicates whether it's a reply or not (green => new subject, blue => reply)
![image](https://user-images.githubusercontent.com/16085366/36028636-0bcdd4a6-0da0-11e8-8aa3-1d5bd71c7862.png)
